### PR TITLE
Feat/restructure header menu

### DIFF
--- a/src/components/app-header.vue
+++ b/src/components/app-header.vue
@@ -5,16 +5,47 @@
         {{ $t('annRadar') }}
       </v-app-bar-title>
 
+      <ScenarioCreateDialog
+        v-if="showScenarioCreateDialog"
+        @close="showScenarioCreateDialog = false"
+      />
+      <ScenarioLoadDialog
+        v-if="showScenarioLoadDialog"
+        @close="showScenarioLoadDialog = false"
+      />
+
       <span class="scenario-name" v-if="scenarioMetaData">
-        {{ $t('scenarios.scenario') + scenarioMetaData.name }}
+        {{ $t('scenarios.scenario') }}: {{ scenarioMetaData.name }}
       </span>
       <div class="header-actions">
-        <ScenarioCreateDialog :disabled="!canCreate" />
-        <ScenarioLoadDialog />
-        <v-btn text @click="saveScenario" :disabled="!canSave">
-          <span>{{ $t('scenarios.saveScenario') }}</span>
-          <v-icon right>mdi-content-save</v-icon>
-        </v-btn>
+        <v-menu open-on-hover bottom offset-y>
+          <template v-slot:activator="{on, attrs}">
+            <v-btn text active-class="primary--text" v-bind="attrs" v-on="on">
+              <span>{{ $t('scenarios.scenario') }}</span>
+            </v-btn>
+          </template>
+
+          <v-list>
+            <v-list-item
+              @click="showScenarioCreateDialog = true"
+              :disabled="!canCreate"
+            >
+              <v-list-item-title>
+                {{ $t('scenarios.createScenario') }}
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item @click="showScenarioLoadDialog = true">
+              <v-list-item-title>
+                {{ $t('scenarios.loadScenario') }}
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item @click="saveScenario" :disabled="!canSave">
+              <v-list-item-title>
+                {{ $t('scenarios.saveScenario') }}
+              </v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
 
         <v-menu open-on-hover bottom offset-y>
           <template v-slot:activator="{on, attrs}">
@@ -147,6 +178,8 @@ import ScenarioLoadDialog from '../components/scenario-load-dialog.vue';
 
 interface Data {
   tab: number;
+  showScenarioCreateDialog: boolean;
+  showScenarioLoadDialog: boolean;
 }
 
 export default Vue.extend({
@@ -162,7 +195,9 @@ export default Vue.extend({
   },
   data(): Data {
     return {
-      tab: 0
+      tab: 0,
+      showScenarioCreateDialog: false,
+      showScenarioLoadDialog: false
     };
   },
   computed: {

--- a/src/components/create-scenario-dialog.vue
+++ b/src/components/create-scenario-dialog.vue
@@ -8,18 +8,7 @@
       @onConfirm="createAndLoad()"
       @onCancel="showConfirm = false"
     />
-    <v-dialog v-model="open" max-width="600px">
-      <template v-slot:activator="{on, attrs}">
-        <v-btn
-          id="tour-create-scenario"
-          text
-          v-bind="attrs"
-          v-on="on"
-          :disabled="disabled"
-        >
-          {{ $t('scenarios.createScenario') }}
-        </v-btn>
-      </template>
+    <v-dialog :value="true" max-width="600px">
       <v-card>
         <v-card-title>{{ $t('scenarios.createScenario') }}</v-card-title>
         <v-card-text>
@@ -31,7 +20,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click="close()">
+          <v-btn color="blue darken-1" text @click="$emit('close')">
             {{ $t('cancel') }}
           </v-btn>
           <v-btn
@@ -59,7 +48,6 @@ import {mapActions, mapState} from 'vuex';
 import ConfirmCreateDialog from './confirm-dialog.vue';
 
 interface Data {
-  open: boolean;
   name: string;
   showConfirm: boolean;
 }
@@ -72,7 +60,6 @@ export default Vue.extend({
   },
   data(): Data {
     return {
-      open: false,
       name: '',
       showConfirm: false
     };
@@ -108,12 +95,8 @@ export default Vue.extend({
 
       this.fetchScenarioDetails({id, ...scenario});
 
-      this.close();
-    },
-    close() {
-      this.name = '';
-      this.open = false;
-      this.showConfirm = false;
+      // Close the dialog
+      this.$emit('close');
     }
   }
 });

--- a/src/components/scenario-load-dialog.vue
+++ b/src/components/scenario-load-dialog.vue
@@ -8,13 +8,7 @@
       @onConfirm="loadScenario"
       @onCancel="showConfirm = false"
     />
-    <v-dialog v-model="open" max-width="600px">
-      <template v-slot:activator="{on, attrs}">
-        <v-btn id="tour-load-scenario" text v-bind="attrs" v-on="on">
-          {{ $t('scenarios.loadScenario') }}
-        </v-btn>
-      </template>
-
+    <v-dialog :value="true" max-width="600px">
       <v-card>
         <v-card-title>{{ $t('scenarios.loadScenario') }}</v-card-title>
         <v-card-text>
@@ -57,7 +51,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click="open = false">
+          <v-btn color="blue darken-1" text @click="$emit('close')">
             {{ $t('cancel') }}
           </v-btn>
           <v-btn
@@ -92,7 +86,6 @@ import {Scenario} from '@/types/scenarios';
 import ConfirmLoadDialog from './confirm-dialog.vue';
 
 interface Data {
-  open: boolean;
   showConfirm: boolean;
   isLoading: boolean;
   savedScenarios: Scenario[];
@@ -101,7 +94,6 @@ interface Data {
 export default Vue.extend({
   data(): Data {
     return {
-      open: false,
       showConfirm: false,
       isLoading: false,
       savedScenarios: [],
@@ -110,19 +102,6 @@ export default Vue.extend({
   },
   components: {
     ConfirmLoadDialog
-  },
-  watch: {
-    async open(newOpenState: boolean) {
-      if (newOpenState) {
-        const scenarios = await this.fetchScenarios();
-        if (scenarios) {
-          this.savedScenarios = scenarios;
-        }
-      } else {
-        // Reset the dialog when it was closed
-        this.resetDialog();
-      }
-    }
   },
   computed: {
     ...(mapState as MapStateToComputed)('root', ['scenarioMetaData'])
@@ -150,23 +129,29 @@ export default Vue.extend({
         return null;
       }
     },
-    resetDialog() {
-      this.selectedScenarioIndex = null;
-      this.isLoading = false;
-    },
     loadScenario() {
       this.showConfirm = false;
       this.isLoading = true;
       const scenarioToSet =
         this.selectedScenarioIndex != null &&
         this.savedScenarios[this.selectedScenarioIndex];
+
       if (!scenarioToSet) {
         this.isLoading = false;
         return;
       }
+
       this.fetchScenarioDetails(scenarioToSet);
+
       // Close the dialog
-      this.open = false;
+      this.$emit('close');
+    }
+  },
+  async created() {
+    const scenarios = await this.fetchScenarios();
+
+    if (scenarios) {
+      this.savedScenarios = scenarios;
     }
   }
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -77,7 +77,7 @@
   },
   "statisticalArea": "Statistical Area",
   "scenarios": {
-    "scenario": "Scenario: ",
+    "scenario": "Scenario",
     "createScenario": "Create Scenario",
     "saveScenario": "Save Scenario",
     "loadScenario": "Load Scenario",


### PR DESCRIPTION
close #267
- move urban testbeds menu to tabs navigation <img width="1264" alt="Bildschirmfoto 2022-08-31 um 12 59 36" src="https://user-images.githubusercontent.com/12370310/187663914-75a19394-060b-4e0f-ba44-afb9a0224f5b.png">
- move scenario buttons into a scenario header menu <img width="1264" alt="Bildschirmfoto 2022-08-31 um 12 59 22" src="https://user-images.githubusercontent.com/12370310/187663921-6c1622a1-2279-4cff-b64b-1b50ed91d519.png">
